### PR TITLE
Enable local play

### DIFF
--- a/risk/custom_maps.py
+++ b/risk/custom_maps.py
@@ -1,0 +1,25 @@
+from igraph import Graph
+from .game_types import MapStructure, Bonus
+
+def create_simple_map():
+    g = Graph()
+    g.add_vertices(9)
+    
+    connections = [
+        (0, 1), (1, 2),    # Connections within Region 1
+        (3, 4), (4, 5),    # Connections within Region 2
+        (6, 7), (7, 8),    # Connections within Region 3
+        (2, 3),            # Connection between Region 1 and Region 2
+        (5, 6)             # Connection between Region 2 and Region 3
+    ]
+    g.add_edges(connections)
+    
+    ids = {i: i for i in range(9)}
+    
+    bonuses = [
+        Bonus("Region 1", {0, 1, 2}, 2),
+        Bonus("Region 2", {3, 4, 5}, 2),
+        Bonus("Region 3", {6, 7, 8}, 2)
+    ]
+    
+    return MapStructure(mapid=1, name="Simple Map", graph=g, bonuses=bonuses, ids=ids)

--- a/scripts/local-play.py
+++ b/scripts/local-play.py
@@ -6,13 +6,15 @@ import os
 from distutils.util import strtobool
 
 import risk
+from risk.custom_maps import create_simple_map
+
 try:
     from risk.nn import *
 except ImportError:
     pass
 
 def __main__(args):
-    mapid = risk.api.MapID[args.map]
+    mapstruct = create_simple_map()
     if args.model_1 is not None:
         model1 = pickle.load(open(args.model_1, "rb"))
     else:
@@ -26,7 +28,7 @@ def __main__(args):
 
     data = {
         "self-play": True,
-        "map": int(mapid),
+        "map": 1,
         "turns": [],
         "winner": None
     }
@@ -44,7 +46,7 @@ def __main__(args):
             alpha=args.alpha_1,
             pop_size=args.pop_size_1,
             mirror_model=args.mirror_model_1,
-            rounds=args.rounds_1,
+            #rounds=args.rounds_1,
     )
     bot2 = args.model_type_2(
             None, 2, 1, model2,
@@ -59,9 +61,9 @@ def __main__(args):
             alpha=args.alpha_2,
             pop_size=args.pop_size_2,
             mirror_model=args.mirror_model_2,
-            rounds=args.rounds_2,
+            #rounds=args.rounds_2,
     )
-    game = risk.LocalGameManager.fromMap(mapid, cache=args.map_cache)
+    game = risk.LocalGameManager(mapstruct)
 
     callbacks = [risk.standard_callback]
     if args.output_dir:


### PR DESCRIPTION
The API communication stopped working, so this adds a hard-coded graph map and remove the network dependency to enable a fully local play.

Code could be cleaner, but it's usable.

